### PR TITLE
ADD USB Code Update enable/disable

### DIFF
--- a/inc/srvcfg_manager.hpp
+++ b/inc/srvcfg_manager.hpp
@@ -67,6 +67,13 @@ class ServiceConfig
     void restartUnitConfig(boost::asio::yield_context yield);
     void startServiceRestartTimer();
 
+#ifdef USB_CODE_UPDATE
+    void saveUSBCodeUpdateStateToFile(const bool& maskedState,
+                                      const bool& enabledState);
+    void getUSBCodeUpdateStateFromFile();
+    void setUSBCodeUpdateState(const bool& state);
+#endif
+
   private:
     sdbusplus::asio::object_server& server;
     std::shared_ptr<sdbusplus::asio::dbus_interface> srvCfgIface;

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,10 @@ deps = [dependency('boost'),
         dependency('systemd'),
 ]
 
+if(get_option('usb-code-update').enabled())
+    add_project_arguments('-DUSB_CODE_UPDATE', language : 'cpp')
+endif
+
 executable('phosphor-srvcfg-manager',
            'src/main.cpp',
            'src/srvcfg_manager.cpp',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option(
+    'usb-code-update', type: 'feature',
+    description: 'Enable USB code update enable/disable feature.',
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,6 +186,15 @@ static inline void
         archive(CEREAL_NVP(unitsToMonitor));
     }
 
+#ifdef USB_CODE_UPDATE
+    unitsToMonitor.emplace(
+        "phosphor_2dusb_2dcode_2dupdate",
+        std::make_tuple(
+            "phosphor_usb_code_update", "",
+            "/org/freedesktop/systemd1/unit/usb_2dcode_2dupdate_2eservice",
+            ""));
+#endif
+
     // create objects for needed services
     for (auto& it : unitsToMonitor)
     {


### PR DESCRIPTION
phosphor_usb_code_update is an application that use USB to do FW
update. phosphor_usb_code_update service is not a daemon, but an app
that will be called after inserting a USB flash disk.

This commit creates an object of phosphor_usb_code_update when
phosphor_usb_code_update is not started. We can enable/disable
phosphor_usb_code_update by setting the "Enabled" property to
true/false.

Please configure the “usb-code-update” option in your bb/bbappend to
enable this feature.

srvcfg_manager don't need to do anything to systemd when we
enable/disable phosphor_usb_code_update, which is different from other
services. We only need to show the "Enabled" property on the object.

When phosphor_usb_code_update is started, it will look for the
"Enabled" property of the object. If the "Enabled" property is
false, it will terminate usb code update.

The commits of phosphor_usb_code_update is:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-bmc-code-mgmt/+/48742/1

Test:
get "Enabled" property：
busctl get-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled
b true

set "Enabled" property to false:
busctl set-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled b false

busctl get-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled
b false

The "Enabled" property will be persisted，reboot the BMC, then get the
"Enabled" property：
busctl get-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled
b false

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>
Change-Id: Iba7ffb541628d563e2c54c3e1c8c4dbe85f1507b