### PR TITLE
Move to OpenSSH (sshd)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ static std::unordered_map<std::string /* unitName */,
                           bool /* isSocketActivated */>
     managedServices = {{"phosphor-ipmi-net", false}, {"bmcweb", false},
                        {"phosphor-ipmi-kcs", false}, {"start-ipkvm", false},
-                       {"obmc-console", false},      {"dropbear", true},
+                       {"obmc-console", false},      {"sshd", true},
                        {"obmc-console-ssh", true}};
 
 enum class UnitType


### PR DESCRIPTION
This changes srvcfg-manager service to support the OpenSSH server instead of the Dropbear SSH server.  That is, it creates a D-Bus object called "sshd" instead of "dropbear".

This change affects all users of the "dropbear" object, for example, if bmcweb hard-coded "dropbear".
The community is exploring a better way to adapt to the choice of SSH server implementation.

Tested: Yes, via bmcweb

This is a followup to https://github.ibm.com/openbmc/openbmc/pull/5620
This compiles okay, but requires all users to adapt to the new "sshd" object.  See https://github.com/ibm-openbmc/bmcweb/pull/1136